### PR TITLE
Replace deprecated flowzone input tests_run_on

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -18,5 +18,5 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
-      tests_run_on: '["windows-2019"]'
+      custom_runs_on: '[["windows-2019"]]'
       restrict_custom_actions: false


### PR DESCRIPTION
The `custom_runs_on` array supports multiple runner labels in nested arrays.

Change-type: patch